### PR TITLE
Add Github Action to run lint and e2e tests on push

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,23 @@
+name: main
+on: [push]
+jobs:
+  cypress-run:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Install packages
+        run: yarn
+      - name: Run ESLint
+        run: eslint --ext .js,.vue ./
+      - name: Run UATs
+        uses: cypress-io/github-action@v1
+        with:
+          start: yarn dev
+          wait-on: http://localhost:8080/
+          config_file: cypress.json
+          spec: "test/cypress/integration/**/*"
+        env:
+          CYPRESS_baseUrl: http://localhost:8080/
+          CYPRESS_ALGOLIA_APP_ID: ${{ secrets.CYPRESS_ALGOLIA_APP_ID }}
+          CYPRESS_ALGOLIA_KEY: ${{ secrets.CYPRESS_ALGOLIA_KEY }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
       - name: Install packages
         run: yarn
       - name: Run ESLint
-        run: ./node_modules/.bin/eslint --ext .js,.vue ./
+        run: yarn lint
       - name: Run UATs
         run: yarn test:e2e:ci
         env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,12 +11,7 @@ jobs:
       - name: Run ESLint
         run: ./node_modules/.bin/eslint --ext .js,.vue ./
       - name: Run UATs
-        uses: cypress-io/github-action@v1
-        with:
-          start: yarn dev
-          wait-on: http://localhost:8080/
-          config_file: cypress.json
-          spec: "test/cypress/integration/**/*"
+        run: yarn test:e2e:ci
         env:
           CYPRESS_baseUrl: http://localhost:8080/
           CYPRESS_ALGOLIA_APP_ID: ${{ secrets.CYPRESS_ALGOLIA_APP_ID }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
       - name: Install packages
         run: yarn
       - name: Run ESLint
-        run: eslint --ext .js,.vue ./
+        run: ./node_modules/.bin/eslint --ext .js,.vue ./
       - name: Run UATs
         uses: cypress-io/github-action@v1
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,14 +7,11 @@ Please note we have a code of conduct, please follow it in all your interactions
 
 ## Pull Request Process
 
-1. Ensure any install or build dependencies are removed before the end of the layer when doing a
-   build.
-2. Update the README.md with details of changes to the interface, this includes new environment
-   variables, useful file locations and container parameters.
-3. Increase the version numbers in any examples files and the README.md to the new version that this
-   Pull Request would represent. The versioning scheme we use is [SemVer](http://semver.org/).
-4. You may merge the Pull Request in once you have the sign-off of two other developers, or if you
-   do not have permission to do that, you may request the second reviewer to merge it for you.
+1. We *highly* encourage [short, concise git commit messages](https://chris.beams.io/posts/git-commit/).
+2. Ensure any eslint (including warnings) and cypress tests pass locally before creating your Pull Request.
+3. After Pull Request creation, your branch must pass the eslint and UAT tests that run automatically.
+4. Your Pull Request must be approved by at least one contributor.
+5. After the tests pass, and it has been approved, you may request one of the contributors to merge it for you.
 
 ## Code of Conduct
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ You need to have a version of Yarn that is >= 1.21.1 installed on the host machi
 * `yarn dev` build and start the app in development mode (hot-code reloading, error reporting, etc.)
 * `yarn build` build the app for production
 * `yarn lint` lint the files for warnings and errors (automatically run when you make a Pull Request)
-* `yarn fix:lint` lint the files for warnings and errors and try to automatically fix
+* `yarn lint:fix` lint the files for warnings and errors and try to automatically fix
 * `yarn test:e2e` open the UAT tool, Cypress, to select test files to run in the browser
 * `yarn test:e2e:ci` run the UAT tests in headless browser mode (automatically run when you make a Pull Request)
 

--- a/README.md
+++ b/README.md
@@ -4,23 +4,33 @@ The definitive website for Persistent Browser-Based Games.
 ### Install the dependencies
 Dependencies are managed with the [Yarn package manager](https://classic.yarnpkg.com/en/docs/install/#mac-stable).
 You need to have a version of Yarn that is >= 1.21.1 installed on the host machine.
-1. `cd pbbg.com`
-2. `yarn`
+
+1. [Fork](https://docs.github.com/en/free-pro-team@latest/github/getting-started-with-github/fork-a-repo) this repository
+2. Clone and `cd` into your new fork.
+3. Create a new branch from `master` with `git checkout -b someNewFeatureOrBugfixBranch`
+4. Install packages by running `yarn` command.
 
 ### Commands
-* `yarn dev` start the app in development mode (hot-code reloading, error reporting, etc.)
-* `yarn lint` lint the files
+* `yarn dev` build and start the app in development mode (hot-code reloading, error reporting, etc.)
 * `yarn build` build the app for production
+* `yarn lint` lint the files for warnings and errors (automatically run when you make a Pull Request)
+* `yarn fix:lint` lint the files for warnings and errors and try to automatically fix
 * `yarn test:e2e` open the UAT tool, Cypress, to select test files to run in the browser
-* `yarn test:e2e:ci` run the UAT tests in headless browser mode (use this for CI build)
+* `yarn test:e2e:ci` run the UAT tests in headless browser mode (automatically run when you make a Pull Request)
 
+### Contributing and Pull Requests
+1. We *highly* encourage [short, concise git commit messages](https://chris.beams.io/posts/git-commit/).
+2. Ensure any eslint (including warnings) and cypress tests pass locally before creating your Pull Request.
+3. After Pull Request creation, your branch must pass the eslint and UAT tests that run automatically.
+4. Your Pull Request must be approved by at least one contributor.
+5. After the tests pass, and it has been approved, you may request one of the contributors to merge it for you.
+
+> Longer Contributing document on how to offer feedback, our standards, responsibilities, code of conduct, and
+>enforcement can be found in [contributing guidelines](/CONTRIBUTING.md)
 
 ### Test Environment
-After developing locally and going through the normal Pull Request process to get your changes added, you should
-be able to see the updated code hosted on the test environment at [https://dev.pbbg.com/](https://dev.pbbg.com/).
-
-## Contributing
-This site is powered by [Vue](https://vuejs.org/). Check out our [contributing guidelines](/CONTRIBUTING.md) for ways to offer feedback and contribute.
+ After developing locally and going through the normal Pull Request process to get your changes added, you should
+ be able to see the updated code hosted on the test environment at [https://dev.pbbg.com/](https://dev.pbbg.com/).
 
 ## Licenses
 Content is released under [GNU GPL v3.0](https://www.gnu.org/licenses/gpl-3.0.en.html).

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Actions Status](https://github.com/foohonpie/pbbg.com/workflows/main/badge.svg)](https://github.com/foohonpie/pbbg.com/actions)
+
 # pbbg.com Website (pbbg.com)
 The definitive website for Persistent Browser-Based Games.
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "dev": "quasar dev",
     "build": "quasar build",
     "lint": "eslint --ext .js,.vue ./",
-    "fix:lint": "eslint --fix --ext .js,.vue ./",
+    "lint:fix": "eslint --fix --ext .js,.vue ./",
     "test": "echo \"No test specified\" && exit 0",
     "test:e2e": "cross-env E2E_TEST=true start-test 'quasar dev' http-get://localhost:8080 'cypress open'",
     "test:e2e:ci": "cross-env E2E_TEST=true start-test 'quasar dev' http-get://localhost:8080 'cypress run'"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   "scripts": {
     "dev": "quasar dev",
     "build": "quasar build",
-    "lint": "eslint --fix --ext .js,.vue ./",
+    "lint": "eslint --ext .js,.vue ./",
+    "fix:lint": "eslint --fix --ext .js,.vue ./",
     "test": "echo \"No test specified\" && exit 0",
     "test:e2e": "cross-env E2E_TEST=true start-test 'quasar dev' http-get://localhost:8080 'cypress open'",
     "test:e2e:ci": "cross-env E2E_TEST=true start-test 'quasar dev' http-get://localhost:8080 'cypress run'"

--- a/test/cypress/util.js
+++ b/test/cypress/util.js
@@ -1,5 +1,10 @@
 export function mockAlgolia () {
-  const queries = `https://tf6ehqug2k-dsn.algolia.net/1/indexes/*/queries?x-algolia-agent=Algolia for JavaScript (3.35.1); Browser (lite); JS Helper (2.28.1); vue-instantsearch 1.7.0&x-algolia-application-id=${Cypress.env('ALGOLIA_APP_ID')}&x-algolia-api-key=${Cypress.env('ALGOLIA_KEY')}`
+  let queries = ''
+  if (process.env.CI === true) {
+    queries = `https://tf6ehqug2k-dsn.algolia.net/1/indexes/*/queries?x-algolia-agent=Algolia for JavaScript (3.35.1); Browser (lite); JS Helper (2.28.1); vue-instantsearch 1.7.0&x-algolia-application-id=${process.env.CYPRESS_ALGOLIA_APP_ID}&x-algolia-api-key=${process.env.CYPRESS_ALGOLIA_KEY}`
+  } else {
+    queries = `https://tf6ehqug2k-dsn.algolia.net/1/indexes/*/queries?x-algolia-agent=Algolia for JavaScript (3.35.1); Browser (lite); JS Helper (2.28.1); vue-instantsearch 1.7.0&x-algolia-application-id=${Cypress.env('ALGOLIA_APP_ID')}&x-algolia-api-key=${Cypress.env('ALGOLIA_KEY')}`
+  }
   cy.fixture('initialAlgoliaResults').as('results')
   cy.server()
   cy.route('POST', queries, '@results')


### PR DESCRIPTION
Adds Github Action - their built in CI runner - to run lint and cypress tests on each push.  It's my first time using github actions so there might be some trial and error - especially since I can't really test it locally.