### PR TITLE
Add dynamic form schemas and field descriptors for DRY form building

### DIFF
--- a/quasar.conf.js
+++ b/quasar.conf.js
@@ -99,7 +99,10 @@ module.exports = function (/* ctx */) {
       // (like functional components as one of the examples),
       // you can manually specify Quasar components/directives to be available everywhere:
       //
-      // components: [],
+      components: [
+        'QInput',
+        'QIcon',
+      ],
       // directives: [],
 
       // Quasar plugins

--- a/src/components/DynamicForm.vue
+++ b/src/components/DynamicForm.vue
@@ -50,6 +50,7 @@ export default {
         :field="field"
         :on-input="onInput"
         :form-models="formModels"
+        class="q-ma-sm"
       />
 
       <div class="row q-gutter-md">

--- a/src/components/DynamicForm.vue
+++ b/src/components/DynamicForm.vue
@@ -1,0 +1,76 @@
+<script>
+import { schema } from '../services/formSchemas.js'
+import { descriptor } from '../services/fieldDescriptors.js'
+export default {
+  props: {
+    formSchema: {
+      type: String,
+      required: true,
+    },
+  },
+  data() {
+    return {
+      formModels: {},
+    }
+  },
+  components: {
+    FormFieldRenderer: () => import('./FormFieldRenderer.vue'),
+  },
+  methods: {
+    onInput(value, field) {
+      this.$set(this.formModels, field, value)
+    },
+    onSubmit() {
+      // this.formModels is the current form values
+      // TODO: do something with generic form submission, possibly via store action
+    },
+  },
+  computed: {
+    fields() {
+      let fields = {}
+      let fieldNames = Object.keys(schema(this.formSchema))
+      fieldNames.map(name => {
+        fields[name] = descriptor(name)
+      })
+      return fields
+    },
+  },
+}
+</script>
+
+<template>
+  <q-page padding>
+    <q-form
+      class="q-gutter-md"
+      @submit="onSubmit"
+    >
+      <form-field-renderer
+        v-for="field in fields"
+        :key="field.model"
+        :field="field"
+        :on-input="onInput"
+        :form-models="formModels"
+      />
+
+      <div class="row q-gutter-md">
+        <q-btn
+          label="Cancel"
+          outline
+          no-caps
+        />
+        <q-btn
+          label="Reset"
+          outline
+          no-caps
+          type="reset"
+        />
+        <q-btn
+          color="primary"
+          label="Save"
+          no-caps
+          type="submit"
+        />
+      </div>
+    </q-form>
+  </q-page>
+</template>

--- a/src/components/FormFieldRenderer.vue
+++ b/src/components/FormFieldRenderer.vue
@@ -1,0 +1,86 @@
+<script>
+export default {
+  props: {
+    field: {
+      type: Object,
+      required: true,
+    },
+    formModels: {
+      type: Object,
+      required: true,
+    },
+    onInput: {
+      type: Function,
+      required: true,
+    },
+  },
+  methods: {
+    assignFieldData(field) {
+      if (!field.fieldOptions) {
+        return {}
+      }
+      const fieldOptions = field.fieldOptions
+      let data = {}
+      if (fieldOptions.attrs && Object.keys(fieldOptions.attrs).length) {
+        data.attrs = {}
+        Object.keys(fieldOptions.attrs).map(key => {
+          if (key.startsWith('_')) {
+            data.attrs[key.substr(1)] = fieldOptions.attrs[key]
+          } else {
+            data.attrs[key] = fieldOptions.attrs[key]
+          }
+        })
+      }
+      if (fieldOptions.class && fieldOptions.class.length) {
+        data.class = fieldOptions.class
+      }
+      if (fieldOptions.on && Object.keys(fieldOptions.on).length) {
+        data.on = {}
+        Object.keys(fieldOptions.on).map(event => {
+          if (event === 'input') {
+            data.on.input = (v) => this.onInput(v, field.model)
+          } else {
+            data.on[event] = fieldOptions.on[event]
+          }
+        })
+      }
+      if (fieldOptions.props && Object.keys(fieldOptions.props).length) {
+        data.props = fieldOptions.props
+      }
+      if (field.model) {
+        data.props.value = this.formModels[field.model]
+      }
+      if (fieldOptions.ref) {
+        data.ref = fieldOptions.ref
+      }
+      if (fieldOptions.slot) {
+        data.slot = fieldOptions.slot
+      }
+      data.style = fieldOptions.style && Object.keys(fieldOptions.style).length ? fieldOptions.style : null
+      return data
+    },
+    appendLabel(h, field) {
+      return h('div', {
+        class: ['text-caption'],
+      }, [
+        field.label,
+      ])
+    },
+    appendComponent(h, field) {
+      if (field.children && Array.isArray(field.children)) {
+        return h(field.component, this.assignFieldData(field), field.children.map(child => this.appendComponent(h, child)))
+      }
+      return h(field.component, this.assignFieldData(field), field.children)
+    },
+  },
+  render(h) {
+    const field = this.field
+    const child = [this.appendLabel(h, field)]
+    child.push(this.appendComponent(h, field))
+    const data = {
+      class: ['column', 'q-gutter-xs'],
+    }
+    return h('div', data, child)
+  },
+}
+</script>

--- a/src/components/FormFieldRenderer.vue
+++ b/src/components/FormFieldRenderer.vue
@@ -59,13 +59,6 @@ export default {
       data.style = fieldOptions.style && Object.keys(fieldOptions.style).length ? fieldOptions.style : null
       return data
     },
-    appendLabel(h, field) {
-      return h('div', {
-        class: ['text-caption'],
-      }, [
-        field.label,
-      ])
-    },
     appendComponent(h, field) {
       if (field.children && Array.isArray(field.children)) {
         return h(field.component, this.assignFieldData(field), field.children.map(child => this.appendComponent(h, child)))
@@ -75,12 +68,10 @@ export default {
   },
   render(h) {
     const field = this.field
-    const child = [this.appendLabel(h, field)]
-    child.push(this.appendComponent(h, field))
     const data = {
       class: ['column', 'q-gutter-xs'],
     }
-    return h('div', data, child)
+    return h('div', data, [this.appendComponent(h, field)])
   },
 }
 </script>

--- a/src/pages/Index.vue
+++ b/src/pages/Index.vue
@@ -1,14 +1,16 @@
 <template>
   <q-page class="q-pa-xl">
+    <!-- <dynamic-form form-schema="user" /> -->
     <instant-search />
   </q-page>
 </template>
 
 <script>
 import InstantSearch from 'components/InstantSearch.vue'
+// import DynamicForm from 'components/DynamicForm.vue'
 
 export default {
   name: 'PageIndex',
-  components: { InstantSearch },
+  components: { InstantSearch/*, DynamicForm*/ },
 }
 </script>

--- a/src/services/fieldDescriptors.js
+++ b/src/services/fieldDescriptors.js
@@ -8,7 +8,6 @@
  * const <field-name> = {
  *    component: '<ui-component-name>',
  *    default: '',               // Default value
- *    label: '<field-label>',
  *    model: '<model-field-name>',
  *    fieldOptions: {
  *       attrs: {                // Native component attributes
@@ -34,40 +33,36 @@
 
 const name = {
   component: 'q-input',
-  label: 'Name',
   model: 'name',
   fieldOptions: {
     class: [],
     on: { input: true },
     attrs: {
       placeholder: 'Enter your full name',
+      _type: 'text',
     },
     props: {
-      filled: true,
+      outlined: true,
+      label: 'Name',
       rules: [val => !!val || 'Field is required'],
-    },
-    style: {
-      width: '200px',
     },
   },
 }
 
 const email = {
   component: 'q-input',
-  label: 'Email',
   model: 'email',
   fieldOptions: {
     class: [],
     on: { input: true },
     attrs: {
       placeholder: 'Enter your email address',
+      _type: 'email',
     },
     props: {
-      filled: true,
+      outlined: true,
+      label: 'Email',
       rules: [val => !!val || 'Field is required'],
-    },
-    style: {
-      width: '200px',
     },
   },
   children: [
@@ -91,20 +86,18 @@ const email = {
 
 const password = {
   component: 'q-input',
-  label: 'Password',
   model: 'password',
   fieldOptions: {
     class: [],
     on: { input: true },
     attrs: {
       placeholder: 'Enter your password',
+      _type: 'password',
     },
     props: {
-      filled: true,
+      outlined: true,
+      label: 'Password',
       rules: [val => !!val || 'Field is required'],
-    },
-    style: {
-      width: '200px',
     },
   },
   children: [

--- a/src/services/fieldDescriptors.js
+++ b/src/services/fieldDescriptors.js
@@ -1,0 +1,141 @@
+/*
+ * Field Descriptor api
+ * ============
+ * NOTE: also remember to import the Quasar UI Component (i.e. QInput, etc..) via quasar.conf.js if it
+ * hasn't been used before.
+ *
+ *
+ * const <field-name> = {
+ *    component: '<ui-component-name>',
+ *    default: '',               // Default value
+ *    label: '<field-label>',
+ *    model: '<model-field-name>',
+ *    fieldOptions: {
+ *       attrs: {                // Native component attributes
+ *          _type: 'password'    // Prefix keyword with '_'
+ *       },
+ *       class: [],
+ *       key: '',
+ *       id: '',
+ *       on: {
+ *          input: true,         // Required to update model
+ *          <event-name>: <event-function>,
+ *       },
+ *       props: {},              // Custom component attributes
+ *       ref: '',
+ *       slot: '',               // Named slot for 'template' components
+ *       style: {},
+ *    },
+ *    children: []
+ * }
+ *
+ *
+ */
+
+const name = {
+  component: 'q-input',
+  label: 'Name',
+  model: 'name',
+  fieldOptions: {
+    class: [],
+    on: { input: true },
+    attrs: {
+      placeholder: 'Enter your full name',
+    },
+    props: {
+      filled: true,
+      rules: [val => !!val || 'Field is required'],
+    },
+    style: {
+      width: '200px',
+    },
+  },
+}
+
+const email = {
+  component: 'q-input',
+  label: 'Email',
+  model: 'email',
+  fieldOptions: {
+    class: [],
+    on: { input: true },
+    attrs: {
+      placeholder: 'Enter your email address',
+    },
+    props: {
+      filled: true,
+      rules: [val => !!val || 'Field is required'],
+    },
+    style: {
+      width: '200px',
+    },
+  },
+  children: [
+    {
+      component: 'template',
+      fieldOptions: {
+        slot: 'prepend',
+      },
+      children: [
+        {
+          component: 'q-icon',
+          fieldOptions: {
+            class: ['cursor-pointer'],
+            props: {name: 'mail'},
+          },
+        },
+      ],
+    },
+  ],
+}
+
+const password = {
+  component: 'q-input',
+  label: 'Password',
+  model: 'password',
+  fieldOptions: {
+    class: [],
+    on: { input: true },
+    attrs: {
+      placeholder: 'Enter your password',
+    },
+    props: {
+      filled: true,
+      rules: [val => !!val || 'Field is required'],
+    },
+    style: {
+      width: '200px',
+    },
+  },
+  children: [
+    {
+      component: 'template',
+      fieldOptions: {
+        slot: 'prepend',
+      },
+      children: [
+        {
+          component: 'q-icon',
+          fieldOptions: {
+            class: ['cursor-pointer'],
+            props: {name: 'lock'},
+          },
+        },
+      ],
+    },
+  ],
+}
+
+const fieldDescriptors = {
+  name,
+  email,
+  password,
+}
+
+export function descriptor(fieldName) {
+  return fieldDescriptors[fieldName] ? fieldDescriptors[fieldName] : throw new Error(`Field Descriptor for ${fieldName} is not defined`)
+}
+
+export default () => {
+  return fieldDescriptors
+}

--- a/src/services/formSchemas.js
+++ b/src/services/formSchemas.js
@@ -1,0 +1,22 @@
+const person = {
+  name: {},
+  email: {},
+}
+
+const user = {
+  ...person,
+  password: {},
+}
+
+const formSchemas = {
+  person,
+  user,
+}
+
+export function schema(schemaName) {
+  return formSchemas[schemaName] ? formSchemas[schemaName] : throw new Error(`Form Schema ${schemaName} is not defined`)
+}
+
+export default () => {
+  return formSchemas
+}


### PR DESCRIPTION
This PR might be better explained and/or demonstrated over a chat.  Essentially this lets us use the `formSchema` to define groupings of form fields.  Each form field (like a "username", "email", "password", etc...) is rendered based on an object definition in `fieldDescriptors`.

Between the *form schema* and the *field descriptors* we should be able to write reusable forms without duplicating forms, form inputs, validation, and other common form concerns in multiple places.  For a final example of how we might use this, I have some commented out code in `Index.vue` where you see: `<dynamic-form form-schema="user" />`.

That `user` corresponds to the form schema of: 
```
const user = {
  ...person,
  password: {},
}
```

An added bonus here is being able to "compose" form schemas from smaller units almost like larger models that extend smaller ones:

```
const person = {
  name: {},
  email: {},
}

const user = {
  ...person, // we take 'person' fields here and are adding 'password' to compose what a 'user' schema is.
  password: {},
}
```

And each of those fields has a corresponding `fieldDescriptor`.  Example being "password" as:

```
const password = {
  component: 'q-input',
  label: 'Password',
  model: 'password',
  fieldOptions: {
    class: [],
    on: { input: true },
    attrs: {
      placeholder: 'Enter your password',
    },
    props: {
      filled: true,
      rules: [val => !!val || 'Field is required'],
    },
    style: {
      width: '200px',
    },
  },
  children: [
    {
      component: 'template',
      fieldOptions: {
        slot: 'prepend',
      },
      children: [
        {
          component: 'q-icon',
          fieldOptions: {
            class: ['cursor-pointer'],
            props: {name: 'lock'},
          },
        },
      ],
    },
  ],
}
```

Now that descriptor may look large and unwieldy (and it is) but consider that we write this field descriptor **one time** and it is reusable everywhere.  It covers the prepended icon, the validation behavior and error messaging, the event delegation, the quasar custom attributes and native html attributes, the input label and placeholder.  It's all right there a single time, nice and DRY, and infinitely nestable via the recursive `children` array.

You'll notice that `FormFieldRenderer.vue` only has a `<script>` tag.  This is using Render Components in Vue.  The "magic" of how this works is actually in line with how Vue.js itself does rendering of components.  From the Vue docs - here's the actual syntax of a render component:

```
// @returns {VNode} 
createElement(   
  // {String | Object | Function}   
  // An HTML tag name, component options, or async   
  // function resolving to one of these. Required.   
  'div',
  // {Object}   
  // A data object corresponding to the attributes   
  // you would use in a template. Optional.   
  {     
    // (see details in the next section below)   
  },    
  // {String | Array}   
  // Children VNodes, built using `createElement()`,   
  // or using strings to get 'text VNodes'. Optional.   
  [     
    'Some text comes first.',     
    createElement('h1', 'A headline'),
    createElement(MyComponent, {
      props: {
        someProp: 'foobar'
      }
    })
  ]
)
```

So, we are basically doing this same thing for our field descriptors.  And just for more context our current `password` descriptor would produce html that looks like this:

```
    <div class="column q-gutter-xs">
      <div class="text-caption">Password</div>
      <label for="f_33668d2d-9ffa-4831-bcaa-5c622dcf3788" class="q-field q-validation-component row no-wrap items-start q-input q-field--filled q-field--focused q-field--with-bottom q-field--error" style="width: 200px;">
        <div class="q-field__inner relative-position col self-stretch column justify-center">
          <div tabindex="-1" class="q-field__control relative-position row no-wrap text-negative">
            <div class="q-field__prepend q-field__marginal row no-wrap items-center">
              <i aria-hidden="true" role="presentation" class="material-icons q-icon notranslate cursor-pointer">lock</i>
            </div>
            <div class="q-field__control-container col relative-position row no-wrap q-anchor--skip">
              <input tabindex="0" placeholder="Enter your password" id="f_33668d2d-9ffa-4831-bcaa-5c622dcf3788" type="text" class="q-field__native q-placeholder">
            </div>
            <div class="q-field__append q-field__marginal row no-wrap items-center q-anchor--skip">
              <i aria-hidden="true" role="presentation" class="material-icons q-icon notranslate text-negative">error</i>
            </div>
          </div>
          <div class="q-field__bottom row items-start q-field__bottom--animated">
            <div class="q-field__messages col">
              <div>Field is required</div>
            </div>
          </div>
        </div>
      </label>
    </div>
```

It's a lot of bang for the buck but requires some looking over and consideration to understand how it works.  Have a look at the comments inside the `fieldDescriptors.js` file for a detailed explanation of what a descriptor does.  Let me know what you think.